### PR TITLE
Fix null dereference when formatting new cells

### DIFF
--- a/Grid32/Grid32Mgr.cpp
+++ b/Grid32/Grid32Mgr.cpp
@@ -958,18 +958,22 @@ void CGrid32Mgr::SetCellFormat(UINT nRow, UINT nCol, const FONTINFO& fi)
 
     // Capture old state
     PGRIDCELL pCell = GetCell(nRow, nCol);
-    op.oldState = *pCell;
+    if (pCell)
+    {
+        op.oldState = *pCell;
+    }
+    else
+    {
+        op.oldState = m_defaultGridCell;
+        pCell = CreateCell(nRow, nCol);
+        if (!pCell) {
+            SetLastError(GRID_ERROR_OUT_OF_MEMORY);
+            SendGridNotification(NM_OUTOFMEMORY);
+            return;
+        }
+    }
 
     // Apply new formatting
-	if (!pCell)
-	{
-		pCell = CreateCell(nRow, nCol);
-		if (!pCell) {
-			SetLastError(GRID_ERROR_OUT_OF_MEMORY);
-			SendGridNotification(NM_OUTOFMEMORY);
-			return;
-		}
-	}
     pCell->fontInfo = fi;
     op.newState = *pCell;
 


### PR DESCRIPTION
## Summary
- ensure `SetCellFormat` safely handles cells that don't exist yet

## Testing
- `g++ -fsyntax-only Grid32/Grid32Mgr.cpp` *(fails: `windows.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687c6fec28a88321a7149f76a25bac7f