### PR TITLE
Fix resource cleanup order for DrawVoidSpace

### DIFF
--- a/Grid32/Grid32Mgr.cpp
+++ b/Grid32/Grid32Mgr.cpp
@@ -615,8 +615,10 @@ void CGrid32Mgr::DrawVoidSpace(HDC hDC)
 
         Rectangle(hDC, nMaxWidth + GetActualRowHeaderWidth(), m_clientRect.top, m_clientRect.right, m_clientRect.bottom);
 
-        DeleteObject(SelectObject(hDC, oldPen));
-        DeleteObject(SelectObject(hDC, oldBrush));
+        SelectObject(hDC, oldPen);
+        SelectObject(hDC, oldBrush);
+        DeleteObject(hPen);
+        DeleteObject(hBrush);
 
         bDrawBorder = true;
     }
@@ -630,8 +632,10 @@ void CGrid32Mgr::DrawVoidSpace(HDC hDC)
 
         Rectangle(hDC, 0, nMaxHeight + GetActualColHeaderHeight(), m_clientRect.right, m_clientRect.bottom);
 
-        DeleteObject(SelectObject(hDC, oldPen));
-        DeleteObject(SelectObject(hDC, oldBrush));
+        SelectObject(hDC, oldPen);
+        SelectObject(hDC, oldBrush);
+        DeleteObject(hPen);
+        DeleteObject(hBrush);
 
         bDrawBorder = true;
     }
@@ -660,7 +664,8 @@ void CGrid32Mgr::DrawVoidSpace(HDC hDC)
         }
 
 
-        DeleteObject(SelectObject(hDC, oldPen));
+        SelectObject(hDC, oldPen);
+        DeleteObject(hPen);
     }
 }
 
@@ -734,7 +739,8 @@ void CGrid32Mgr::DrawSelectionSurround(HDC hDC)
     hOldBrush = (HBRUSH)SelectObject(hDC, GetStockObject(NULL_BRUSH));
     Rectangle(hDC, startPt.x, startPt.y, endPt.x, endPt.y);
     SelectObject(hDC, hOldBrush);
-    DeleteObject(SelectObject(hDC, hOldPen));
+    SelectObject(hDC, hOldPen);
+    DeleteObject(hPen);
     hPen = NULL;
 }
 


### PR DESCRIPTION
## Summary
- restore GDI objects before deleting them in `DrawVoidSpace` and `DrawSelectionSurround`

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -c Grid32/Grid32Mgr.cpp -o /tmp/Grid32Mgr.o` *(fails: CommCtrl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687c89eaea6883219f41688e950abb47