### PR TITLE
Extend GM_SETCHARFORMAT to accept ranges

### DIFF
--- a/Grid32/Grid32Mgr.cpp
+++ b/Grid32/Grid32Mgr.cpp
@@ -1079,6 +1079,40 @@ void CGrid32Mgr::SetCellFormat(UINT nRow, UINT nCol, const FONTINFO& fi)
     SetLastError(0);
 }
 
+void CGrid32Mgr::SetSelectionFormat(const FONTINFO& fi)
+{
+    GRIDSELECTION sel = m_selectionRect;
+    NormalizeSelectionRect(sel);
+    SetRangeFormat(sel, fi);
+}
+
+void CGrid32Mgr::SetRangeFormat(const GRIDSELECTION& selRange, const FONTINFO& fi)
+{
+    GRIDSELECTION sel = selRange;
+    NormalizeSelectionRect(sel);
+
+    bool record = m_bUndoRecordEnabled;
+    m_bUndoRecordEnabled = false;
+    for (UINT r = sel.start.nRow; r <= sel.end.nRow && r < gcs.nHeight; ++r)
+    {
+        for (UINT c = sel.start.nCol; c <= sel.end.nCol && c < gcs.nWidth; ++c)
+        {
+            PGRIDCELL cell = GetCellOrCreate(r, c, false);
+            GridEditOperation op;
+            op.type = EditOperationType::SetFormat;
+            op.row = r;
+            op.col = c;
+            op.oldState = *cell;
+            cell->fontInfo = fi;
+            op.newState = *cell;
+            RecordUndoOperation(op);
+        }
+    }
+    m_bUndoRecordEnabled = record;
+    Invalidate();
+    SetLastError(0);
+}
+
 
 
 

--- a/Grid32/Grid32Mgr.h
+++ b/Grid32/Grid32Mgr.h
@@ -104,7 +104,9 @@ public:
 	UINT GetCellTextLen(UINT nRow, UINT nCol);
 	void GetCurrentCellText(LPWSTR pText, UINT nLen);
 	void GetCellText(const GRIDPOINT& gridPt, LPWSTR pText, UINT nLen);
-	void SetCellFormat(UINT nRow, UINT nCol, const FONTINFO& fontInfo);
+        void SetCellFormat(UINT nRow, UINT nCol, const FONTINFO& fontInfo);
+        void SetSelectionFormat(const FONTINFO& fontInfo);
+        void SetRangeFormat(const GRIDSELECTION& sel, const FONTINFO& fontInfo);
 	void GetCellText(UINT nRow, UINT nCol, LPWSTR pText, UINT nLen);
 	void SetCell(UINT nRow, UINT nCol, const GRIDCELL& gc);
 	void SetCurrentCellText(LPCWSTR newText);

--- a/Grid32/grid32.h
+++ b/Grid32/grid32.h
@@ -112,6 +112,11 @@ struct tagGCSTREAM;
 #define GM_SETCHARFORMAT			(WM_USER + 23)
 #define GM_STREAMIN					(WM_USER + 24)
 #define GM_STREAMOUT				(WM_USER + 25)
+// GM_SETCHARFORMAT wParam flags
+#define SCF_CURRENTCELL 0x0000
+#define SCF_SELECTION 0x0001
+#define SCF_RANGE 0x0002
+
 
 // Grid32 Error
 
@@ -199,6 +204,13 @@ typedef struct {
 	LPWSTR wszBuff;
 	UINT nLen;
 }GRID_GETTEXT;
+typedef struct tagGCCELLCHARFORMAT
+{
+    UINT m_cbSize;
+    GRIDSELECTION m_range;
+    FONTINFO m_format;
+} GCCELLCHARFORMAT, *LPGCCELLCHARFORMAT;
+
 
 typedef struct tagGRIDNMHDR : tagNMHDR {
 	// Add custom members for your notification data

--- a/Grid32/grid32_wndproc.cpp
+++ b/Grid32/grid32_wndproc.cpp
@@ -223,8 +223,22 @@ LRESULT CALLBACK CGrid32Mgr::Grid32_WndProc(HWND hWnd, UINT uMsg, WPARAM wParam,
         case GM_SETCHARFORMAT:
             if (lParam)
             {
-                PFONTINFO pInfo = reinterpret_cast<PFONTINFO>(lParam);
-                pMgr->SetCellFormat(pMgr->m_currentCell.nRow, pMgr->m_currentCell.nCol, *pInfo);
+                if (wParam == SCF_RANGE)
+                {
+                    LPGCCELLCHARFORMAT pCF = reinterpret_cast<LPGCCELLCHARFORMAT>(lParam);
+                    if (pCF->m_cbSize == sizeof(GCCELLCHARFORMAT))
+                        pMgr->SetRangeFormat(pCF->m_range, pCF->m_format);
+                }
+                else if (wParam == SCF_SELECTION)
+                {
+                    PFONTINFO pInfo = reinterpret_cast<PFONTINFO>(lParam);
+                    pMgr->SetSelectionFormat(*pInfo);
+                }
+                else
+                {
+                    PFONTINFO pInfo = reinterpret_cast<PFONTINFO>(lParam);
+                    pMgr->SetCellFormat(pMgr->m_currentCell.nRow, pMgr->m_currentCell.nCol, *pInfo);
+                }
             }
             break;
 

--- a/Spreadsheet/GridCtrl.cpp
+++ b/Spreadsheet/GridCtrl.cpp
@@ -58,6 +58,20 @@ BOOL CGridCtrl::SetCurrentCellFormat(const FONTINFO& fi)
     return ::SendMessage(m_hWnd, GM_SETCHARFORMAT, 0, (LPARAM)&fi) != 0;
 }
 
+BOOL CGridCtrl::SetSelectionFormat(const FONTINFO& fi)
+{
+    return ::SendMessage(m_hWnd, GM_SETCHARFORMAT, SCF_SELECTION, (LPARAM)&fi) != 0;
+}
+
+BOOL CGridCtrl::SetRangeFormat(const GRIDSELECTION& sel, const FONTINFO& fi)
+{
+    GCCELLCHARFORMAT cf{};
+    cf.m_cbSize = sizeof(GCCELLCHARFORMAT);
+    cf.m_range = sel;
+    cf.m_format = fi;
+    return ::SendMessage(m_hWnd, GM_SETCHARFORMAT, SCF_RANGE, (LPARAM)&cf) != 0;
+}
+
 DWORD CGridCtrl::GetLastError()
 {
     return (DWORD)::SendMessage(m_hWnd, GM_GETLASTERROR, 0, 0);

--- a/Spreadsheet/GridCtrl.h
+++ b/Spreadsheet/GridCtrl.h
@@ -16,6 +16,8 @@ public:
 	BOOL SetCurrentCell(LPCWSTR pwszRef, short nWhich);
     BOOL SetCurrentCell(UINT nRow, UINT nCol);
     BOOL SetCurrentCellFormat(const FONTINFO& fi);
+    BOOL SetSelectionFormat(const FONTINFO& fi);
+    BOOL SetRangeFormat(const GRIDSELECTION& sel, const FONTINFO& fi);
     DWORD GetLastError();
 
 protected:


### PR DESCRIPTION
## Summary
- allow GM_SETCHARFORMAT to work on the current selection or an arbitrary range
- add helper methods to apply character formats over selections/ranges
- expose new APIs in the sample control wrapper

## Testing
- `g++ -c Grid32/Grid32Mgr.cpp -o /tmp/test.o` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687d1fa0b1988321ad3c6f84a90ed61c