### PR TITLE
Fix warning about size_t to UINT conversion

### DIFF
--- a/Grid32/Grid32Mgr.cpp
+++ b/Grid32/Grid32Mgr.cpp
@@ -3362,7 +3362,7 @@ void CGrid32Mgr::OnStreamOut(LPGCSTREAM pStream)
         {
             for (size_t c = 0; c < gcs.nWidth; ++c)
             {
-                PGRIDCELL cell = GetCell(r, c);
+                PGRIDCELL cell = GetCell(static_cast<UINT>(r), static_cast<UINT>(c));
                 if (cell)
                     ss << cell->m_wsText;
                 if (c + 1 < gcs.nWidth)
@@ -3417,7 +3417,7 @@ void CGrid32Mgr::OnStreamOut(LPGCSTREAM pStream)
                 ss << L"<table:table-row>";
                 for (size_t c = 0; c < gcs.nWidth; ++c)
                 {
-                    PGRIDCELL cell = GetCell(r, c);
+                    PGRIDCELL cell = GetCell(static_cast<UINT>(r), static_cast<UINT>(c));
                     ss << L"<table:table-cell office:value-type=\"string\"><text:p>";
                     if (cell)
                         ss << EscapeXML(cell->m_wsText);
@@ -3437,7 +3437,7 @@ void CGrid32Mgr::OnStreamOut(LPGCSTREAM pStream)
                 ss << L"<row r=\"" << r + 1 << L"\">";
                 for (size_t c = 0; c < gcs.nWidth; ++c)
                 {
-                    PGRIDCELL cell = GetCell(r, c);
+                    PGRIDCELL cell = GetCell(static_cast<UINT>(r), static_cast<UINT>(c));
                     ss << L"<c r=\"" << r + 1 << L"" << (wchar_t)(L'A' + c) << L"\" t=\"inlineStr\"><is><t>";
                     if (cell)
                         ss << EscapeXML(cell->m_wsText);


### PR DESCRIPTION
## Summary
- fix implicit size_t to UINT conversion in `OnStreamOut`

## Testing
- `x86_64-w64-mingw32-g++ -c Grid32/Grid32Mgr.cpp -IGrid32 -I/usr/x86_64-w64-mingw32/include -std=c++17 -Wall` *(fails: CommCtrl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687da2256be88321a89c0abc8082fc1f